### PR TITLE
push request format

### DIFF
--- a/metro/proto/v1/spec.proto
+++ b/metro/proto/v1/spec.proto
@@ -778,3 +778,12 @@ message AdminTopic {
 
     int32 num_partitions = 3;
 }
+
+// Request made on the push endpoint
+message PushEndpointRequest {
+    // Required. The messages to publish.
+    PubsubMessage message = 1 [(google.api.field_behavior) = REQUIRED];
+
+    // Required. The message in the request was published for this subscription.
+    string subscription = 2 [(google.api.field_behavior) = REQUIRED];
+}


### PR DESCRIPTION
- Defines a request format in which messages would be delivered on the push-endpoint. This is compliant to the one Google Pub-Sub uses.

```
{
  "message": {
    "data": "Y2ttY3Nsa21jc2lvY20=",
    "messageId": "2451898607221267",
    "message_id": "2451898607221267",
    "publishTime": "2021-05-24T17:08:03.509Z",
    "publish_time": "2021-05-24T17:08:03.509Z"
  },
  "subscription": "projects/grand-quarter-314716/subscriptions/metro-sub-1"
}
```