### PR TITLE
Bump to latest golang

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15.5
+          go-version: 1.19.2
       - name: make local
         if: success()
         run: make local


### PR DESCRIPTION
1.15 is no longer supported: https://endoflife.date/go